### PR TITLE
Load assets over https instead of http

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,13 +180,13 @@
   </div>
   </div>
   <div class="out">
-    Created by <a href="http://makehatsgreatagain.us">Make Hats Great Again</a>
+    Created by <a href="https://makehatsgreatagain.us">Make Hats Great Again</a>
   </div>
 
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
   <script src="/jquery.lightbox_me.js?2"></script>
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/lettering.js/0.7.0/jquery.lettering.min.js"></script>
-  <script src="http://cdn.jsdelivr.net/jquery.circletype/0.34/circletype.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lettering.js/0.7.0/jquery.lettering.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/jquery.circletype/0.34/circletype.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/0.4.1/html2canvas.js"></script>
 
   <script>


### PR DESCRIPTION
Chrome will block assets if the HTML is loaded over https and the assets are loaded over http. Since Chrome loads over https by default, this means that the site won't function unless assets are loaded over https.